### PR TITLE
Fix int slider popup closing immediately

### DIFF
--- a/1.6/Source/TabulaRasa/UI/Popup_IntSlider.cs
+++ b/1.6/Source/TabulaRasa/UI/Popup_IntSlider.cs
@@ -11,11 +11,17 @@ namespace TabulaRasa
 {
     public class Popup_IntSlider : Window
     {
+        private const float Width = 215f;
+        private const float Height = 75f;
+        private const float CursorGap = 8f;
+
         private readonly string _label;
         private readonly int _floor;
         private readonly int _ceiling;
         private readonly Func<int> _current;
         private readonly Action<int> _callback;
+
+        public override Vector2 InitialSize => new Vector2(Width, Height);
 
         public Popup_IntSlider(string label, int floor, int ceiling, Func<int> current, Action<int> callback)
         {
@@ -24,33 +30,21 @@ namespace TabulaRasa
             _ceiling = ceiling;
             _current = current;
             _callback = callback;
+
+            closeOnClickedOutside = true;
         }
 
         public override void SetInitialSizeAndPosition()
         {
-            var vector = Verse.UI.MousePositionOnUIInverted;
-            if (vector.x + InitialSize.x > Verse.UI.screenWidth)
-            {
-                vector.x = Verse.UI.screenWidth - InitialSize.x;
-            }
-            if (vector.y + InitialSize.y - 50 > Verse.UI.screenHeight)
-            {
-                vector.y = Verse.UI.screenHeight - InitialSize.y - 50;
-            }
-            windowRect = new Rect(vector.x, vector.y + InitialSize.y - 100, 215, 75);
+            var size = InitialSize;
+            var position = Verse.UI.MousePositionOnUIInverted;
+            position.x = Mathf.Clamp(position.x, 0f, Verse.UI.screenWidth - size.x);
+            position.y = Mathf.Clamp(position.y - size.y - CursorGap, 0f, Verse.UI.screenHeight - size.y);
+            windowRect = new Rect(position.x, position.y, size.x, size.y);
         }
 
         public override void DoWindowContents(Rect rect)
         {
-            if (!rect.Contains(Event.current.mousePosition))
-            {
-                var num = GenUI.DistFromRect(rect, Event.current.mousePosition);
-                if (num > 75f)
-                {
-                    Close(false);
-                    return;
-                }
-            }
             _callback((int)Widgets.HorizontalSlider(
                     new Rect(5, 10, 165f, 25f),
                     _current(),


### PR DESCRIPTION
Fixes Popup_IntSlider closing immediately when opened from shield gizmos.

The popup previously closed whenever the mouse was more than 75 px from its contents during DoWindowContents. This was brittle and made the Shield Generators radius slider impossible to use in some cases.

This gives the popup explicit dimensions, positions it near the cursor with screen clamping, and uses closeOnClickedOutside instead.